### PR TITLE
feat: tests order package

### DIFF
--- a/sources/order.move
+++ b/sources/order.move
@@ -700,3 +700,71 @@ fun calculate_fee(amount: u64, winner: Actor, fee_info: &FeeInfo): u64 {
 public fun test_init(ctx: &mut TxContext) {
     init(ctx);
 }
+
+// --------------------
+// === Test Helpers ===
+// --------------------
+#[test_only]
+use sui::test_utils::assert_eq;
+
+#[test_only]
+fun status_to_code(status: &NoteStatus): u64 {
+    if (types::is_note_status_win(status)) {
+        0
+    } else if (types::is_note_status_loss(status)) {
+        1
+    } else if (types::is_note_status_refund(status)) {
+        2
+    } else {
+        3
+    }
+}
+
+#[test_only]
+public fun assert_note_created_event(
+    expected_note_id: u64,
+    expected_taker: address,
+    expected_maker: address,
+    expected_asset: TradableAsset,
+    expected_amount: u64,
+    expected_expiry_time: u64,
+) {
+    let emitted = event::events_by_type<NoteCreated>()[0];
+    assert_eq(emitted.note_id, expected_note_id);
+    assert_eq(emitted.taker, expected_taker);
+    assert_eq(emitted.maker, expected_maker);
+    // Compare enum via string conversion utility to avoid type mismatches
+    let emitted_asset_str = types::tradable_asset_to_string(&emitted.asset);
+    let expected_asset_str = types::tradable_asset_to_string(&expected_asset);
+    assert!(std::string::as_bytes(&emitted_asset_str) == std::string::as_bytes(&expected_asset_str), EInvalidNote);
+    assert_eq(emitted.amount, expected_amount);
+    assert_eq(emitted.expiry_time, expected_expiry_time);
+}
+
+#[test_only]
+public fun assert_note_settled_event(
+    expected_note_id: u64,
+    expected_status_code: u64,
+    expected_settlement_price: u64,
+    expected_payout: u64,
+    expected_fee: u64,
+) {
+    let emitted = event::events_by_type<NoteSettled>()[0];
+    assert_eq(emitted.note_id, expected_note_id);
+    assert_eq(status_to_code(&emitted.status), expected_status_code);
+    assert_eq(emitted.settlement_price, expected_settlement_price);
+    assert_eq(emitted.payout, expected_payout);
+    assert_eq(emitted.fee, expected_fee);
+}
+
+#[test_only]
+public fun assert_taker_fee_percentage_changed_event(expected_percentage: u64) {
+    let emitted = event::events_by_type<TakerFeePercentageChanged>()[0];
+    assert_eq(emitted.taker_fee_percentage, expected_percentage);
+}
+
+#[test_only]
+public fun assert_maker_fee_percentage_changed_event(expected_percentage: u64) {
+    let emitted = event::events_by_type<MakerFeePercentageChanged>()[0];
+    assert_eq(emitted.maker_fee_percentage, expected_percentage);
+}

--- a/sources/order.move
+++ b/sources/order.move
@@ -690,9 +690,11 @@ fun process_settlement<T, IthacaType>(
 fun calculate_fee(amount: u64, winner: Actor, fee_info: &FeeInfo): u64 {
     let max_fee = types::max_fee_percentage();
     if (types::is_actor_maker(&winner)) {
-        (amount * types::fee_info_maker_percentage(fee_info)) / max_fee
+        let result: u256 = (amount as u256) * (types::fee_info_maker_percentage(fee_info) as u256) / (max_fee as u256);
+        result as u64
     } else {
-        (amount * types::fee_info_taker_percentage(fee_info)) / max_fee
+        let result: u256 = (amount as u256) * (types::fee_info_taker_percentage(fee_info) as u256) / (max_fee as u256);
+        result as u64
     }
 }
 

--- a/sources/order.move
+++ b/sources/order.move
@@ -17,6 +17,9 @@ const VERSION: u64 = 1;
 // === Errors ===
 
 #[error]
+const ENotZeroAddress: vector<u8> = b"Address cannot be zero";
+
+#[error]
 const EInvalidNote: vector<u8> = b"Invalid note data provided";
 
 #[error]
@@ -169,6 +172,8 @@ public fun initialize<T>(
     treasury: address,
     ctx: &mut TxContext
 ): (CoordinatorCap) {
+    validate_address(treasury);
+
     let coordinator_cap = CoordinatorCap {
         id: object::new(ctx),
     };
@@ -473,6 +478,11 @@ public fun treasury<T>(order_manager: &OrderManager<T>): address {
 }
 
 // === Helper Functions ===
+
+/// Validate that address is not zero
+public fun validate_address(addr: address) {
+    assert!(addr != @0x0, ENotZeroAddress);
+}
 
 /// Update taker locked balance
 fun update_taker_locked_balance<T>(

--- a/sources/types.move
+++ b/sources/types.move
@@ -75,7 +75,7 @@ public struct FeeInfo has copy, drop, store {
 
 // === Constants ===
 
-const MAX_FEE_PERCENTAGE: u64 = 1000000000000000000; // 1e18
+const MAX_FEE_PERCENTAGE: u64 = 1000000000; // 1e9 (Sui uses 9 decimals)
 
 // === Public functions ===
 

--- a/sources/types.move
+++ b/sources/types.move
@@ -75,7 +75,7 @@ public struct FeeInfo has copy, drop, store {
 
 // === Constants ===
 
-const MAX_FEE_PERCENTAGE: u64 = 1000000000; // 1e9 (Sui uses 9 decimals)
+const MAX_FEE_PERCENTAGE: u64 = 10000; // 1e5 (allows for 2 decimal places, e.g. 10000 = 100.00%)
 
 // === Public functions ===
 

--- a/tests/maker_vault_tests.move
+++ b/tests/maker_vault_tests.move
@@ -409,7 +409,7 @@ public fun test_custom_minimum_stake_other_asset_allows_deposit() {
 public fun test_withdraw_collateral_success() {
     let mut scenario = setup_test_scenario();
     let (_, _, _, maker1, _, _, _) = get_test_addresses();
-    let (vault_unused, mut maker_vault, mut order_manager) = setup_complete_system(&mut scenario, none());
+    let (vault_unused, mut maker_vault, mut order_manager) = setup_complete_system(&mut scenario, none(), none());
 
     // Ensure maker registered and deposit collateral
     let stake_amount = get_minimum_stake();
@@ -449,7 +449,7 @@ public fun test_withdraw_collateral_success() {
 public fun test_cannot_withdraw_zero_amount() {
     let mut scenario = setup_test_scenario();
     let (_, _, _, maker1, _, _, _) = get_test_addresses();
-    let (vault_unused, mut maker_vault, mut order_manager) = setup_complete_system(&mut scenario, none());
+    let (vault_unused, mut maker_vault, mut order_manager) = setup_complete_system(&mut scenario, none(), none());
 
     let stake_amount = get_minimum_stake();
     register_test_maker(&mut scenario, &mut maker_vault, maker1, stake_amount);
@@ -472,7 +472,7 @@ public fun test_cannot_withdraw_zero_amount() {
 public fun test_cannot_withdraw_if_not_registered_maker() {
     let mut scenario = setup_test_scenario();
     let (_, _, _, maker1, _, _, _) = get_test_addresses();
-    let (vault_unused, mut maker_vault, mut order_manager) = setup_complete_system(&mut scenario, none());
+    let (vault_unused, mut maker_vault, mut order_manager) = setup_complete_system(&mut scenario, none(), none());
 
     // maker1 not registered
     test_scenario::next_tx(&mut scenario, maker1);
@@ -490,7 +490,7 @@ public fun test_cannot_withdraw_if_not_registered_maker() {
 public fun test_cannot_withdraw_more_than_available() {
     let mut scenario = setup_test_scenario();
     let (_, _, _, maker1, _, _, _) = get_test_addresses();
-    let (vault_unused, mut maker_vault, mut order_manager) = setup_complete_system(&mut scenario, none());
+    let (vault_unused, mut maker_vault, mut order_manager) = setup_complete_system(&mut scenario, none(), none());
 
     let stake_amount = get_minimum_stake();
     register_test_maker(&mut scenario, &mut maker_vault, maker1, stake_amount);
@@ -644,7 +644,7 @@ public fun test_unregister_success_after_withdrawing_all_collateral() {
     let deposit_amount = 50_000;
     deposit_maker_collateral(&mut scenario, &mut maker_vault, maker1, types::tradable_asset_btc(), deposit_amount);
 
-    let (vault_tmp, maker_vault_tmp, mut order_manager) = setup_complete_system(&mut scenario, none());
+    let (vault_tmp, maker_vault_tmp, mut order_manager) = setup_complete_system(&mut scenario, none(), none());
     test_scenario::return_shared(vault_tmp);
     test_scenario::return_shared(maker_vault_tmp);
 

--- a/tests/order_tests.move
+++ b/tests/order_tests.move
@@ -1,68 +1,759 @@
+#[test_only]
+module odyssey_sui::order_tests;
+
+use sui::test_scenario::{Self, ctx};
+use sui::test_utils::assert_eq;
+use std::option::none;
+use std::option::some;
+
+use odyssey_sui::test_utils::{
+    Self,
+    setup_test_scenario,
+    get_test_addresses,
+    cleanup_scenario,
+    setup_complete_system,
+    setup_funded_scenario,
+    create_test_note,
+    create_custom_note,
+    deposit_trader_funds,
+    get_minimum_stake,
+    mint_ithaca,
+    mint_usdc,
+    create_test_clock,
+    advance_time,
+    timestamp_plus_days,
+    USDC,
+};
+use odyssey_sui::types;
+use odyssey_sui::order::{Self, CoordinatorCap};
+use odyssey_sui::maker_vault;
+use odyssey_sui::test_utils::setup_order_manager;
+
 // ==========
 // Initialization Tests
 // ==========
+#[test]
+#[expected_failure(abort_code = order::ENotZeroAddress)]
+public fun test_initialize_fails_with_zero_treasury() {
+    let mut scenario = setup_test_scenario();
+    let (governor, _, _, _, _, _, _) = get_test_addresses();
 
-// cannot initialize with zero address treasury
+    let zero_address = @0x0;
+    test_scenario::next_tx(&mut scenario, governor);
+    let (vault, maker_vault, order_manager) = setup_complete_system(&mut scenario, none(), some(zero_address));
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+
+
+    cleanup_scenario(scenario)
+}
 
 // ==========
 // Create Note Tests
 // ==========
 
-// can create note (including emit event)
-// cannot create note if amount is zero
-// cannot create note if taker is zero address
-// cannot create note if maker is zero address
-// cannot create note if almost win payout is more than win payout
-// cannot create note if almost win payout is zero
-// cannot create note if almost win spread is more than win spread
-// cannot create note if taker balance less than amount
-// cannot create note if maker balance is less than win amount
-// cannot create note if expiry date not in future
-// cannot create note if start date is more than expiry date
-// cannot create note if payout is less or equal to bet amount
-// cannot create note if refund payout is bigger than bet amount
-// locks correct amount of collateral from maker and taker
+#[test]
+public fun test_create_note_success_and_event_and_locks() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager) = setup_complete_system(&mut scenario, none(), none());
 
+    // Fund actors
+    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+    let amount1 = 1_000;
+    let win_payout1 = amount1 * 3;
+
+    // Register maker and fund balances
+    let stake_amount = get_minimum_stake();
+    test_scenario::next_tx(&mut scenario, maker1);
+    let ithaca = mint_ithaca(&mut scenario, maker1, stake_amount);
+    maker_vault::register_maker(&mut maker_vault, ithaca, ctx(&mut scenario));
+
+    // Ensure maker collateral sufficient and taker funds available
+    test_scenario::next_tx(&mut scenario, maker1);
+    let maker_collateral = 10_000;
+    let usdc_for_maker = mint_usdc(&mut scenario, maker1, maker_collateral);
+    maker_vault::deposit_collateral(&mut maker_vault, types::tradable_asset_btc(), usdc_for_maker, ctx(&mut scenario));
+
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, amount1);
+
+    // Create note
+    let clock = create_test_clock(&mut scenario, 1);
+    let note = create_test_note(trader1, maker1, amount1, win_payout1, 2);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap = scenario.take_from_sender<CoordinatorCap>();
+    let note_id = order::create_note(&coordinator_cap, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap);
+
+    // Assert event
+    order::assert_note_created_event(note_id, trader1, maker1, types::tradable_asset_btc(), amount1, types::note_expiry_time(&note));
+
+    // Locks
+    test_scenario::next_tx(&mut scenario, trader1);
+    let taker_locked = order::taker_locked_balance(&order_manager, trader1);
+    assert_eq(taker_locked, amount1);
+
+    test_scenario::next_tx(&mut scenario, maker1);
+    let maker_locked = order::maker_locked_balance(&order_manager, maker1, types::tradable_asset_btc());
+    assert_eq(maker_locked, win_payout1 - amount1);
+
+    // Create another note and validate cumulative locks
+    let amount2 = 300;
+    let win_payout2 = amount2 * 10;
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, amount2);
+
+    let note2 = create_test_note(trader1, maker1, amount2, win_payout2, 2);
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap2 = scenario.take_from_sender<CoordinatorCap>();
+    let _ = order::create_note(&coordinator_cap2, &mut order_manager, &mut vault, &mut maker_vault, note2, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap2);
+
+    test_scenario::next_tx(&mut scenario, trader1);
+    let taker_locked_after = order::taker_locked_balance(&order_manager, trader1);
+    assert_eq(taker_locked_after, amount1 + amount2);
+
+    test_scenario::next_tx(&mut scenario, maker1);
+    let maker_locked_after = order::maker_locked_balance(&order_manager, maker1, types::tradable_asset_btc());
+    assert_eq(maker_locked_after, (win_payout1 - amount1) + (win_payout2 - amount2));
+
+    // destroy clock
+    clock.destroy_for_testing();
+
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    cleanup_scenario(scenario)
+}
+
+#[test]
+#[expected_failure(abort_code = order::EInvalidNote)]
+public fun test_cannot_create_note_with_zero_amount() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    // Ensure trader funded
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, 1);
+
+    // amount = 0
+    let note = types::new_note(trader1, maker1, types::tradable_asset_btc(), types::direction_up(), 0, 84000, 15, 100, timestamp_plus_days(&clock, 2), 0, 0, 10, 1, 1);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap = scenario.take_from_sender<CoordinatorCap>();
+    let _ = order::create_note(&coordinator_cap, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap);
+
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    clock.destroy_for_testing();
+    cleanup_scenario(scenario)
+}
+
+#[test]
+#[expected_failure(abort_code = order::EInvalidNote)]
+public fun test_cannot_create_note_with_zero_taker_or_maker() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    // Fund trader
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, 100);
+
+    // taker is zero address
+    let note1 = types::new_note(@0x0, maker1, types::tradable_asset_btc(), types::direction_up(), 10, 84000, 15, 30, timestamp_plus_days(&clock, 2), 0, 10, 10, 20, 1);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap = scenario.take_from_sender<CoordinatorCap>();
+    let _ = order::create_note(&coordinator_cap, &mut order_manager, &mut vault, &mut maker_vault, note1, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap);
+
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    clock.destroy_for_testing();
+    cleanup_scenario(scenario)
+}
+
+#[test]
+#[expected_failure(abort_code = order::EInvalidPayout)]
+public fun test_cannot_create_note_with_invalid_payouts() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, 1000);
+
+    // win_payout <= amount
+    let note = types::new_note(trader1, maker1, types::tradable_asset_btc(), types::direction_up(), 100, 84000, 15, 100, timestamp_plus_days(&clock, 2), 0, 100, 10, 0, 1);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap = scenario.take_from_sender<CoordinatorCap>();
+    let _ = order::create_note(&coordinator_cap, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap);
+
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    clock.destroy_for_testing();
+    cleanup_scenario(scenario)
+}
+
+#[test]
+#[expected_failure(abort_code = order::EInvalidPayout)]
+public fun test_cannot_create_note_with_refund_payout_bigger_than_amount() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, 1000);
+
+    let note = types::new_note(trader1, maker1, types::tradable_asset_btc(), types::direction_up(), 100, 84000, 15, 200, timestamp_plus_days(&clock, 2), 0, 101, 10, 100, 1);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap = scenario.take_from_sender<CoordinatorCap>();
+    let _ = order::create_note(&coordinator_cap, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap);
+
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    clock.destroy_for_testing();
+    cleanup_scenario(scenario)
+}
+
+#[test]
+#[expected_failure(abort_code = order::EInvalidPayout)]
+public fun test_cannot_create_note_with_almost_win_payout_zero_or_more_than_win() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, 1000);
+
+    // almost win payout = 0
+    let note = types::new_note(trader1, maker1, types::tradable_asset_btc(), types::direction_up(), 100, 84000, 15, 200, timestamp_plus_days(&clock, 2), 0, 100, 10, 0, 1);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap = scenario.take_from_sender<CoordinatorCap>();
+    let _ = order::create_note(&coordinator_cap, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap);
+
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    clock.destroy_for_testing();
+    cleanup_scenario(scenario)
+}
+
+#[test]
+#[expected_failure(abort_code = order::EInvalidSpread)]
+public fun test_cannot_create_note_with_almost_win_spread_more_than_spread() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, 1000);
+
+    let note = types::new_note(trader1, maker1, types::tradable_asset_btc(), types::direction_up(), 100, 84000, 15, 200, timestamp_plus_days(&clock, 2), 0, 100, 16, 100, 1);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap = scenario.take_from_sender<CoordinatorCap>();
+    let _ = order::create_note(&coordinator_cap, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap);
+
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    clock.destroy_for_testing();
+    cleanup_scenario(scenario)
+}
+
+#[test]
+#[expected_failure(abort_code = order::EInsufficientTakerBalance)]
+public fun test_cannot_create_note_if_taker_balance_less_than_amount() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    // Fund trader less than amount
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, 99);
+
+    let note = create_custom_note(trader1, maker1, types::tradable_asset_btc(), types::direction_up(), 100, 84000, 15, 300, timestamp_plus_days(&clock, 2), 100, 10, 100);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap = scenario.take_from_sender<CoordinatorCap>();
+    let _ = order::create_note(&coordinator_cap, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap);
+
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    clock.destroy_for_testing();
+    cleanup_scenario(scenario)
+}
+
+#[test]
+#[expected_failure(abort_code = order::EInsufficientMakerBalance)]
+public fun test_cannot_create_note_if_maker_balance_less_than_win_amount() {
+    let mut scenario = setup_test_scenario();
+    // Use clean system to avoid pre-funded maker collateral
+    let (mut vault, mut maker_vault, mut order_manager) = setup_complete_system(&mut scenario, none(), none());
+    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    // Fund trader sufficiently
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, 100);
+
+    // Note requires maker win collateral of 800 (900 - 100) but maker has 0 -> should fail
+    let clock = create_test_clock(&mut scenario, 1);
+    let note = create_custom_note(trader1, maker1, types::tradable_asset_btc(), types::direction_up(), 100, 84000, 15, 900, timestamp_plus_days(&clock, 2), 100, 10, 100);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap = scenario.take_from_sender<CoordinatorCap>();
+    let _ = order::create_note(&coordinator_cap, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap);
+
+    // Cleanup
+    clock.destroy_for_testing();
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    cleanup_scenario(scenario)
+}
+
+#[test]
+#[expected_failure(abort_code = order::EInvalidExpiryTime)]
+public fun test_cannot_create_note_if_expiry_not_in_future() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    // Fund trader sufficiently
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, 100);
+
+    // expiry <= now
+    let note = create_custom_note(trader1, maker1, types::tradable_asset_btc(), types::direction_up(), 100, 84000, 15, 300, /* expiry */ timestamp_plus_days(&clock, 0), 100, 10, 100);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap = scenario.take_from_sender<CoordinatorCap>();
+    let _ = order::create_note(&coordinator_cap, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap);
+
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    clock.destroy_for_testing();
+    cleanup_scenario(scenario)
+}
+
+#[test]
+#[expected_failure(abort_code = order::EInvalidExpiryTime)]
+public fun test_cannot_create_note_if_start_more_than_expiry() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, 100);
+
+    // Manually craft note with start_time > expiry_time
+    let expiry = test_utils::timestamp_plus_days(&clock, 1);
+    let start_time = expiry + 1;
+    let note = types::new_note(trader1, maker1, types::tradable_asset_btc(), types::direction_up(), 100, 84000, 15, 300, expiry, 0, 100, 10, 150, start_time);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap = scenario.take_from_sender<CoordinatorCap>();
+    let _ = order::create_note(&coordinator_cap, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap);
+
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    clock.destroy_for_testing();
+    cleanup_scenario(scenario)
+}
 
 // ==========
 // Settle Note Tests
 // ==========
 
-// success settle note with win status when bet direction is up (check: emitted event, locked collateral)
-// success settle note with win status when bet direction is down (check: emitted event, locked collateral)
-// success settle note with lose status when bet direction is up (check: emitted event, locked collateral)
-// success settle note with lose status when bet direction is down (check: emitted event, locked collateral)
-// success settle note with refund status when bet direction is up (check: emitted event, locked collateral)
-// success settle note with refund status when bet direction is down (check: emitted event, locked collateral)
-// success settle note with almost win status when bet direction is up (check: emitted event, locked collateral)
-// success settle note with almost win status when bet direction is down (check: emitted event, locked collateral)
+#[test]
+public fun test_settle_win_up_direction() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
 
-// cuts fee from win amount when bet is won
-// cuts fee from win amount when bet is lost
-// doesn't cut fee when bet is refunded
-// cuts fee when bet is almost win and payout is less than amount
-// cuts fee when bet is almost win and payout is same as amount
-// cuts fee when bet is almost win and payout is more than amount
-// cuts fee based on refundPayout if refundPayout is set
-// 
+    // Prepare note
+    let amount = 1_000;
+    let win_payout = amount * 3; // win_amount = 2000
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, amount);
+    let note = create_test_note(trader1, maker1, amount, win_payout, 2);
 
-// cannot settle note if note is not available
-// cannot settle same note twice
-// cannot settle note if expiry date not passed
-// cannot settle note if report timestamp is less expiry time
-// cannot settle note if report timestamp is greater expiry time
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap = scenario.take_from_sender<CoordinatorCap>();
+    let note_id = order::create_note(&coordinator_cap, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap);
+
+    // Advance time past expiry and set taker fee
+    test_scenario::next_tx(&mut scenario, coordinator);
+    advance_time(&mut clock, 3 * 24 * 60 * 60 * 1000);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let spot_price = 84000 + 16; // > start + spread -> win
+    let coordinator_cap2 = scenario.take_from_sender<CoordinatorCap>();
+    order::settle_note(&coordinator_cap2, &mut order_manager, &mut vault, &mut maker_vault, note_id, spot_price, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap2);
+
+    // Assert event
+    order::assert_note_settled_event(note_id, 0, spot_price, win_payout, 0);
+
+    // Locks reduced
+    test_scenario::next_tx(&mut scenario, trader1);
+    assert_eq(order::taker_locked_balance(&order_manager, trader1), 0);
+    test_scenario::next_tx(&mut scenario, maker1);
+    assert_eq(order::maker_locked_balance(&order_manager, maker1, types::tradable_asset_btc()), 0);
+
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    clock.destroy_for_testing();
+    cleanup_scenario(scenario)
+}
+
+#[test]
+public fun test_settle_loss_up_direction() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    let amount = 1_000;
+    let win_payout = amount * 3;
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, amount);
+    let note = create_test_note(trader1, maker1, amount, win_payout, 2);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap = scenario.take_from_sender<CoordinatorCap>();
+    let note_id = order::create_note(&coordinator_cap, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap);
+
+    // expire then settle with price just above start -> LOSS
+    test_scenario::next_tx(&mut scenario, coordinator);
+    advance_time(&mut clock, 3 * 24 * 60 * 60 * 1000);
+
+    let spot_price = 84000 + 1; // > start and <= start+almost_win_spread => LOSS
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap2 = scenario.take_from_sender<CoordinatorCap>();
+    order::settle_note(&coordinator_cap2, &mut order_manager, &mut vault, &mut maker_vault, note_id, spot_price, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap2);
+
+    order::assert_note_settled_event(note_id, 1, spot_price, amount, 0);
+
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    clock.destroy_for_testing();
+    cleanup_scenario(scenario)
+}
+
+#[test]
+public fun test_settle_refund_up_direction() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    let amount = 1_000;
+    let win_payout = amount * 3;
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, amount);
+    let note = create_test_note(trader1, maker1, amount, win_payout, 2);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap = scenario.take_from_sender<CoordinatorCap>();
+    let note_id = order::create_note(&coordinator_cap, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    advance_time(&mut clock, 3 * 24 * 60 * 60 * 1000);
+
+    let spot_price = 84000 - 1; // < start => REFUND
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap2 = scenario.take_from_sender<CoordinatorCap>();
+    order::settle_note(&coordinator_cap2, &mut order_manager, &mut vault, &mut maker_vault, note_id, spot_price, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap2);
+
+    order::assert_note_settled_event(note_id, 2, spot_price, amount, 0);
+
+    clock.destroy_for_testing();
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    cleanup_scenario(scenario)
+}
+
+#[test]
+public fun test_settle_almost_win_up_direction() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    let amount = 1_000;
+    let win_payout = amount * 3;
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, amount);
+    let note = create_test_note(trader1, maker1, amount, win_payout, 2);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap = scenario.take_from_sender<CoordinatorCap>();
+    let note_id = order::create_note(&coordinator_cap, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    advance_time(&mut clock, 3 * 24 * 60 * 60 * 1000);
+
+    let spot_price = 84000 + 11; // > start + almost_win_spread (10) and <= spread (15)
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap2 = scenario.take_from_sender<CoordinatorCap>();
+    order::settle_note(&coordinator_cap2, &mut order_manager, &mut vault, &mut maker_vault, note_id, spot_price, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap2);
+
+    order::assert_note_settled_event(note_id, 3, spot_price, types::note_almost_win_payout(&note), 0);
+
+    clock.destroy_for_testing();
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    cleanup_scenario(scenario)
+}
+
+#[test]
+public fun test_settle_variants_down_direction() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    let amount = 1_000;
+    let win_payout = amount * 3;
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, amount);
+
+    let note = create_custom_note(
+        trader1,
+        maker1,
+        types::tradable_asset_btc(),
+        types::direction_down(),
+        amount,
+        84000,
+        15,
+        win_payout,
+        test_utils::timestamp_plus_days(&clock, 2),
+        amount,
+        10,
+        amount + (win_payout - amount) / 2,
+    );
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap = scenario.take_from_sender<CoordinatorCap>();
+    let note_id = order::create_note(&coordinator_cap, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    advance_time(&mut clock, 3 * 24 * 60 * 60 * 1000);
+
+    // Win for DOWN: spot < start - spread
+    let spot_price_win = 84000 - 16;
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coord2 = scenario.take_from_sender<CoordinatorCap>();
+    order::settle_note(&coord2, &mut order_manager, &mut vault, &mut maker_vault, note_id, spot_price_win, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coord2);
+
+    order::assert_note_settled_event(note_id, 0, spot_price_win, win_payout, 0);
+
+    clock.destroy_for_testing();
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    cleanup_scenario(scenario)
+}
+
+#[test]
+#[expected_failure(abort_code = order::ENoteNotFound)]
+public fun test_cannot_settle_nonexistent_note() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_, _, _, _, _, _, coordinator) = get_test_addresses();
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap = scenario.take_from_sender<CoordinatorCap>();
+    order::settle_note(&coordinator_cap, &mut order_manager, &mut vault, &mut maker_vault, 999, 83000, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap);
+
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    clock.destroy_for_testing();
+    cleanup_scenario(scenario)
+}
+
+#[test]
+#[expected_failure(abort_code = order::ENoteAlreadySettled)]
+public fun test_cannot_settle_same_note_twice() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    let amount = 500;
+    let win_payout = amount * 3;
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, amount);
+    let note = create_test_note(trader1, maker1, amount, win_payout, 1);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coord = scenario.take_from_sender<CoordinatorCap>();
+    let note_id = order::create_note(&coord, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coord);
+
+    advance_time(&mut clock, 2 * 24 * 60 * 60 * 1000);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coord2 = scenario.take_from_sender<CoordinatorCap>();
+    order::settle_note(&coord2, &mut order_manager, &mut vault, &mut maker_vault, note_id, 84000 + 16, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coord2);
+
+    // Second settle should fail
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coord3 = scenario.take_from_sender<CoordinatorCap>();
+    order::settle_note(&coord3, &mut order_manager, &mut vault, &mut maker_vault, note_id, 84000 + 16, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coord3);
+
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    clock.destroy_for_testing();
+    cleanup_scenario(scenario)
+}
+
+#[test]
+#[expected_failure(abort_code = order::ENoteNotExpired)]
+public fun test_cannot_settle_before_expiry() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    let amount = 500;
+    let win_payout = amount * 3;
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, amount);
+    let note = create_test_note(trader1, maker1, amount, win_payout, 2);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coord = scenario.take_from_sender<CoordinatorCap>();
+    let note_id = order::create_note(&coord, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coord);
+
+    // No time advance
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coord2 = scenario.take_from_sender<CoordinatorCap>();
+    order::settle_note(&coord2, &mut order_manager, &mut vault, &mut maker_vault, note_id, 84000 + 16, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coord2);
+
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    clock.destroy_for_testing();
+    cleanup_scenario(scenario)
+}
 
 // ==========
-// Set Maker Fee Percentage Tests
+// Fee Percentage Tests
 // ==========
 
-// success set fee percentage
-// cannot set fee percentage greater than 1e18
+#[test]
+public fun test_set_maker_fee_percentage_success_and_event() {
+    let mut scenario = setup_test_scenario();
+    let (mut order_manager) = {
+        let (vault, maker_vault, om) = setup_complete_system(&mut scenario, none(), none());
+        test_scenario::return_shared(vault);
+        test_scenario::return_shared(maker_vault);
+        (om)
+    };
 
-// ==========
-// Set Taker Fee Percentage Tests
-// ==========
+    let (governor, _, _, _, _, _, _) = get_test_addresses();
+    let new_percentage = 123;
 
-// success set fee percentage
-// cannot set fee percentage greater than 1e18
+    test_scenario::next_tx(&mut scenario, governor);
+    let admin_cap = scenario.take_from_sender<order::OrderAdminCap>();
+    order::set_maker_fee_percentage(&admin_cap, &mut order_manager, new_percentage);
+    order::assert_maker_fee_percentage_changed_event(new_percentage);
+    scenario.return_to_sender(admin_cap);
+
+    test_scenario::return_shared(order_manager);
+    cleanup_scenario(scenario)
+}
+
+#[test]
+#[expected_failure(abort_code = order::EInvalidFeePercentage)]
+public fun test_cannot_set_maker_fee_percentage_above_max() {
+    let mut scenario = setup_test_scenario();
+    let (mut order_manager) = {
+        let (vault, maker_vault, om) = setup_complete_system(&mut scenario, none(), none());
+        test_scenario::return_shared(vault);
+        test_scenario::return_shared(maker_vault);
+        (om)
+    };
+
+    let (governor, _, _, _, _, _, _) = get_test_addresses();
+
+    test_scenario::next_tx(&mut scenario, governor);
+    let admin_cap = scenario.take_from_sender<order::OrderAdminCap>();
+    let too_high = types::max_fee_percentage() + 1;
+    order::set_maker_fee_percentage(&admin_cap, &mut order_manager, too_high);
+    scenario.return_to_sender(admin_cap);
+
+    test_scenario::return_shared(order_manager);
+    cleanup_scenario(scenario)
+}
+
+#[test]
+public fun test_set_taker_fee_percentage_success_and_event() {
+    let mut scenario = setup_test_scenario();
+    let (mut order_manager) = {
+        let (vault, maker_vault, om) = setup_complete_system(&mut scenario, none(), none());
+        test_scenario::return_shared(vault);
+        test_scenario::return_shared(maker_vault);
+        (om)
+    };
+
+    let (governor, _, _, _, _, _, _) = get_test_addresses();
+    let new_percentage = 456;
+
+    test_scenario::next_tx(&mut scenario, governor);
+    let admin_cap = scenario.take_from_sender<order::OrderAdminCap>();
+    order::set_taker_fee_percentage(&admin_cap, &mut order_manager, new_percentage);
+    order::assert_taker_fee_percentage_changed_event(new_percentage);
+    scenario.return_to_sender(admin_cap);
+
+    test_scenario::return_shared(order_manager);
+    cleanup_scenario(scenario)
+}
+
+#[test]
+#[expected_failure(abort_code = order::EInvalidFeePercentage)]
+public fun test_cannot_set_taker_fee_percentage_above_max() {
+    let mut scenario = setup_test_scenario();
+    let (mut order_manager) = {
+        let (vault, maker_vault, om) = setup_complete_system(&mut scenario, none(), none());
+        test_scenario::return_shared(vault);
+        test_scenario::return_shared(maker_vault);
+        (om)
+    };
+
+    let (governor, _, _, _, _, _, _) = get_test_addresses();
+
+    test_scenario::next_tx(&mut scenario, governor);
+    let admin_cap = scenario.take_from_sender<order::OrderAdminCap>();
+    let too_high = types::max_fee_percentage() + 1;
+    order::set_taker_fee_percentage(&admin_cap, &mut order_manager, too_high);
+    scenario.return_to_sender(admin_cap);
+
+    test_scenario::return_shared(order_manager);
+    cleanup_scenario(scenario)
+}
 

--- a/tests/order_tests.move
+++ b/tests/order_tests.move
@@ -26,6 +26,7 @@ use odyssey_sui::test_utils::{
 use odyssey_sui::types;
 use odyssey_sui::order::{Self, CoordinatorCap};
 use odyssey_sui::maker_vault;
+use odyssey_sui::vault;
 
 // ==========
 // Initialization Tests
@@ -403,7 +404,7 @@ public fun test_cannot_create_note_if_start_more_than_expiry() {
 public fun test_settle_win_up_direction() {
     let mut scenario = setup_test_scenario();
     let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
-    let (governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+    let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
 
     // Set taker fee percentage to 0.1% (smaller to avoid overflow)
     let taker_fee_percentage = 1000000000000000u64; // 0.1%
@@ -413,6 +414,9 @@ public fun test_settle_win_up_direction() {
     let amount = 1_000;
     let win_payout = amount * 3; // win_amount = 2000
     deposit_trader_funds(&mut scenario, &mut vault, trader1, amount);
+
+    let prev_taker_balance = vault::taker_balance(&vault, trader1);
+    let prev_maker_balance = maker_vault::get_maker_collateral(&maker_vault, maker1, &types::tradable_asset_btc());
     let note = create_test_note(trader1, maker1, amount, win_payout, 2);
 
     test_scenario::next_tx(&mut scenario, coordinator);
@@ -436,6 +440,27 @@ public fun test_settle_win_up_direction() {
 
     // Assert event with fee
     order::assert_note_settled_event(note_id, 0, spot_price, win_payout, expected_fee);
+
+    let amount_after_fee = winning_amount - expected_fee; // 1998
+
+    // Verify taker balance
+    test_scenario::next_tx(&mut scenario, trader1);
+    let final_taker_balance = vault::taker_balance(&vault, trader1);
+    assert_eq(final_taker_balance, prev_taker_balance + amount_after_fee); // Taker gets amount after fee
+
+    // Verify maker balance
+    test_scenario::next_tx(&mut scenario, maker1);
+    let final_maker_balance = maker_vault::get_maker_collateral(&maker_vault, maker1, &types::tradable_asset_btc());
+    assert_eq(final_maker_balance, prev_maker_balance - winning_amount); // Maker loses the full winning amount
+
+    // Verify vault total asset availability
+    let final_vault_asset = vault::total_asset_available(&vault);
+    assert_eq(final_vault_asset, prev_taker_balance + amount_after_fee); // Vault has amount after fee
+
+    // Verify maker vault total asset availability
+    let final_maker_vault_asset = maker_vault::total_asset_available(&maker_vault);
+    debug::print(&final_maker_vault_asset);
+    assert_eq(final_maker_vault_asset, prev_maker_balance - winning_amount);
 
     // Locks reduced
     test_scenario::next_tx(&mut scenario, trader1);

--- a/tests/order_tests.move
+++ b/tests/order_tests.move
@@ -406,8 +406,8 @@ public fun test_settle_win_up_direction() {
     let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
     let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
 
-    // Set taker fee percentage to 0.1% (smaller to avoid overflow)
-    let taker_fee_percentage = 1000000000000000u64; // 0.1%
+    // Set taker fee percentage to 5%
+    let taker_fee_percentage = 50000000u64; // 5% (1e9 precision)
     test_utils::set_fee_percentages(&mut scenario, &mut order_manager, taker_fee_percentage, 0);
 
     // Prepare note
@@ -434,14 +434,14 @@ public fun test_settle_win_up_direction() {
     order::settle_note(&coordinator_cap2, &mut order_manager, &mut vault, &mut maker_vault, note_id, spot_price, &clock, ctx(&mut scenario));
     scenario.return_to_sender(coordinator_cap2);
 
-    // Calculate expected fee: 0.1% of winning amount (2000)
+    // Calculate expected fee: 5% of winning amount (2000)
     let winning_amount = win_payout - amount; // 2000
-    let expected_fee = (winning_amount * taker_fee_percentage) / types::max_fee_percentage(); // 2
+    let expected_fee = (winning_amount * taker_fee_percentage) / types::max_fee_percentage(); // 100
 
     // Assert event with fee
     order::assert_note_settled_event(note_id, 0, spot_price, win_payout, expected_fee);
 
-    let amount_after_fee = winning_amount - expected_fee; // 1998
+    let amount_after_fee = winning_amount - expected_fee; // 1900
 
     // Verify taker balance
     test_scenario::next_tx(&mut scenario, trader1);
@@ -480,8 +480,8 @@ public fun test_settle_loss_up_direction() {
     let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
     let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
 
-    // Set maker fee percentage to 0.1% (smaller to avoid overflow)
-    let maker_fee_percentage = 1000000000000000u64; // 0.1%
+    // Set maker fee percentage to 10%
+    let maker_fee_percentage = 100000000u64; // 10% (1e9 precision)
     test_utils::set_fee_percentages(&mut scenario, &mut order_manager, 0, maker_fee_percentage);
 
     let amount = 1_000;
@@ -508,12 +508,12 @@ public fun test_settle_loss_up_direction() {
     order::settle_note(&coordinator_cap2, &mut order_manager, &mut vault, &mut maker_vault, note_id, spot_price, &clock, ctx(&mut scenario));
     scenario.return_to_sender(coordinator_cap2);
 
-    // Calculate expected fee: 0.1% of loss amount (1000)
-    let expected_fee = (amount * maker_fee_percentage) / types::max_fee_percentage(); // 1
+    // Calculate expected fee: 10% of loss amount (1000)
+    let expected_fee = (amount * maker_fee_percentage) / types::max_fee_percentage(); // 100
 
     order::assert_note_settled_event(note_id, 1, spot_price, amount, expected_fee);
 
-    let amount_after_fee = amount - expected_fee; // 999
+    let amount_after_fee = amount - expected_fee; // 900
     
     // Verify taker balance
     test_scenario::next_tx(&mut scenario, trader1);
@@ -547,7 +547,7 @@ public fun test_settle_refund_up_direction() {
     let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
 
     // Set both fee percentages to make sure no fees are applied on refund
-    let fee_percentage = 1000000000000000u64; // 0.1%
+    let fee_percentage = 50000000u64; // 5% (1e9 precision)
     test_utils::set_fee_percentages(&mut scenario, &mut order_manager, fee_percentage, fee_percentage);
 
     let amount = 1_000;
@@ -682,7 +682,7 @@ public fun test_settle_almost_win_up_direction() {
     let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
 
     // Set both fee percentages to test almost win scenario
-    let fee_percentage = 1000000000000000u64; // 0.1%
+    let fee_percentage = 75000000u64; // 7.5% (1e9 precision)
     test_utils::set_fee_percentages(&mut scenario, &mut order_manager, fee_percentage, fee_percentage);
 
     let amount = 1_000;
@@ -711,13 +711,13 @@ public fun test_settle_almost_win_up_direction() {
     // For almost win, the payout is greater than amount, so taker gains and pays fee
     // almost_win_payout = 2000, amount = 1000, transfer = 1000
     let transfer_amount = types::note_almost_win_payout(&note) - amount; // 1000
-    let expected_fee = (transfer_amount * fee_percentage) / types::max_fee_percentage(); // 1
+    let expected_fee = (transfer_amount * fee_percentage) / types::max_fee_percentage(); // 75
 
     order::assert_note_settled_event(note_id, 3, spot_price, types::note_almost_win_payout(&note), expected_fee);
 
     let almost_win_payout = types::note_almost_win_payout(&note);
     let transfer_amount = almost_win_payout - amount; // 1000
-    let amount_after_fee = transfer_amount - expected_fee; // 999
+    let amount_after_fee = transfer_amount - expected_fee; // 925
 
     // Verify taker balance
     test_scenario::next_tx(&mut scenario, trader1);
@@ -751,7 +751,7 @@ public fun test_settle_almost_win_equal_amount_up_direction() {
     let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
 
     // Set fees (should not apply when no transfer)
-    let fee_percentage = 1000000000000000u64; // 0.1%
+    let fee_percentage = 60000000u64; // 6% (1e9 precision)
     test_utils::set_fee_percentages(&mut scenario, &mut order_manager, fee_percentage, fee_percentage);
 
     let amount = 1_000_000;
@@ -823,7 +823,7 @@ public fun test_settle_almost_win_less_than_amount_up_direction() {
     let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
 
     // Maker fee will apply when maker gains
-    let maker_fee_percentage = 1000000000000000u64; // 0.1%
+    let maker_fee_percentage = 80000000u64; // 8% (1e9 precision)
     test_utils::set_fee_percentages(&mut scenario, &mut order_manager, 0, maker_fee_percentage);
 
     let amount = 1_000_000;
@@ -866,7 +866,7 @@ public fun test_settle_almost_win_less_than_amount_up_direction() {
     scenario.return_to_sender(coord2);
 
     let transferred = amount - almost_win_payout; // 100_000
-    let expected_fee = (transferred * maker_fee_percentage) / types::max_fee_percentage(); // 100
+    let expected_fee = (transferred * maker_fee_percentage) / types::max_fee_percentage(); // 8000
 
     order::assert_note_settled_event(note_id, 3, spot_price, almost_win_payout, expected_fee);
 
@@ -901,7 +901,7 @@ public fun test_settle_variants_down_direction() {
     let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
 
     // Set taker fee percentage for win scenario
-    let taker_fee_percentage = 1000000000000000u64; // 0.1%
+    let taker_fee_percentage = 90000000u64; // 9% (1e9 precision)
     test_utils::set_fee_percentages(&mut scenario, &mut order_manager, taker_fee_percentage, 0);
 
     let amount = 1_000;
@@ -940,14 +940,14 @@ public fun test_settle_variants_down_direction() {
     order::settle_note(&coord2, &mut order_manager, &mut vault, &mut maker_vault, note_id, spot_price_win, &clock, ctx(&mut scenario));
     scenario.return_to_sender(coord2);
 
-    // Calculate expected fee: 0.1% of winning amount (2000)
+    // Calculate expected fee: 9% of winning amount (2000)
     let winning_amount = win_payout - amount; // 2000
-    let expected_fee = (winning_amount * taker_fee_percentage) / types::max_fee_percentage(); // 2
+    let expected_fee = (winning_amount * taker_fee_percentage) / types::max_fee_percentage(); // 180
 
     // Assert event with fee
     order::assert_note_settled_event(note_id, 0, spot_price_win, win_payout, expected_fee);
 
-    let amount_after_fee = winning_amount - expected_fee; // 1998
+    let amount_after_fee = winning_amount - expected_fee; // 1820
 
     // Verify taker balance
     test_scenario::next_tx(&mut scenario, trader1);

--- a/tests/order_tests.move
+++ b/tests/order_tests.move
@@ -1,0 +1,68 @@
+// ==========
+// Initialization Tests
+// ==========
+
+// cannot initialize with zero address treasury
+
+// ==========
+// Create Note Tests
+// ==========
+
+// can create note (including emit event)
+// cannot create note if amount is zero
+// cannot create note if taker is zero address
+// cannot create note if maker is zero address
+// cannot create note if almost win payout is more than win payout
+// cannot create note if almost win payout is zero
+// cannot create note if almost win spread is more than win spread
+// cannot create note if taker balance less than amount
+// cannot create note if maker balance is less than win amount
+// cannot create note if expiry date not in future
+// cannot create note if start date is more than expiry date
+// cannot create note if payout is less or equal to bet amount
+// cannot create note if refund payout is bigger than bet amount
+// locks correct amount of collateral from maker and taker
+
+
+// ==========
+// Settle Note Tests
+// ==========
+
+// success settle note with win status when bet direction is up (check: emitted event, locked collateral)
+// success settle note with win status when bet direction is down (check: emitted event, locked collateral)
+// success settle note with lose status when bet direction is up (check: emitted event, locked collateral)
+// success settle note with lose status when bet direction is down (check: emitted event, locked collateral)
+// success settle note with refund status when bet direction is up (check: emitted event, locked collateral)
+// success settle note with refund status when bet direction is down (check: emitted event, locked collateral)
+// success settle note with almost win status when bet direction is up (check: emitted event, locked collateral)
+// success settle note with almost win status when bet direction is down (check: emitted event, locked collateral)
+
+// cuts fee from win amount when bet is won
+// cuts fee from win amount when bet is lost
+// doesn't cut fee when bet is refunded
+// cuts fee when bet is almost win and payout is less than amount
+// cuts fee when bet is almost win and payout is same as amount
+// cuts fee when bet is almost win and payout is more than amount
+// cuts fee based on refundPayout if refundPayout is set
+// 
+
+// cannot settle note if note is not available
+// cannot settle same note twice
+// cannot settle note if expiry date not passed
+// cannot settle note if report timestamp is less expiry time
+// cannot settle note if report timestamp is greater expiry time
+
+// ==========
+// Set Maker Fee Percentage Tests
+// ==========
+
+// success set fee percentage
+// cannot set fee percentage greater than 1e18
+
+// ==========
+// Set Taker Fee Percentage Tests
+// ==========
+
+// success set fee percentage
+// cannot set fee percentage greater than 1e18
+

--- a/tests/order_tests.move
+++ b/tests/order_tests.move
@@ -59,7 +59,7 @@ public fun test_create_note_success_and_event_and_locks() {
 
     // Fund actors
     let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
-    let amount1 = 1_000;
+    let amount1 = 1_000_000_000_000; // 1000 USDC with 9 decimal precision
     let win_payout1 = amount1 * 3;
 
     // Register maker and fund balances
@@ -70,7 +70,7 @@ public fun test_create_note_success_and_event_and_locks() {
 
     // Ensure maker collateral sufficient and taker funds available
     test_scenario::next_tx(&mut scenario, maker1);
-    let maker_collateral = 10_000;
+    let maker_collateral = 50_000_000_000_000; // 50,000 USDC with 9 decimal precision
     let usdc_for_maker = mint_usdc(&mut scenario, maker1, maker_collateral);
     maker_vault::deposit_collateral(&mut maker_vault, types::tradable_asset_btc(), usdc_for_maker, ctx(&mut scenario));
 
@@ -98,8 +98,8 @@ public fun test_create_note_success_and_event_and_locks() {
     assert_eq(maker_locked, win_payout1 - amount1);
 
     // Create another note and validate cumulative locks
-    let amount2 = 300;
-    let win_payout2 = amount2 * 10;
+    let amount2 = 100_000_000_000; // 100 USDC with 9 decimal precision
+    let win_payout2 = amount2 * 3; // More reasonable payout
     deposit_trader_funds(&mut scenario, &mut vault, trader1, amount2);
 
     let note2 = create_test_note(trader1, maker1, amount2, win_payout2, 2);
@@ -407,12 +407,12 @@ public fun test_settle_win_up_direction() {
     let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
 
     // Set taker fee percentage to 5%
-    let taker_fee_percentage = 50000000u64; // 5% (1e9 precision)
+    let taker_fee_percentage = 5000u64; // 5% (5 decimal precision)
     test_utils::set_fee_percentages(&mut scenario, &mut order_manager, taker_fee_percentage, 0);
 
     // Prepare note
-    let amount = 1_000;
-    let win_payout = amount * 3; // win_amount = 2000
+    let amount = 1_000_000_000_000; // 1000 USDC with 9 decimal precision
+    let win_payout = amount * 3; // win_amount = 3000 USDC
     deposit_trader_funds(&mut scenario, &mut vault, trader1, amount);
 
     let prev_taker_balance = vault::taker_balance(&vault, trader1);
@@ -429,19 +429,19 @@ public fun test_settle_win_up_direction() {
     advance_time(&mut clock, 3 * 24 * 60 * 60 * 1000);
 
     test_scenario::next_tx(&mut scenario, coordinator);
-    let spot_price = 84000 + 16; // > start + spread -> win
+    let spot_price = 84000000000000 + 16000000000; // > start + spread -> win (9 decimal precision)
     let coordinator_cap2 = scenario.take_from_sender<CoordinatorCap>();
     order::settle_note(&coordinator_cap2, &mut order_manager, &mut vault, &mut maker_vault, note_id, spot_price, &clock, ctx(&mut scenario));
     scenario.return_to_sender(coordinator_cap2);
 
-    // Calculate expected fee: 5% of winning amount (2000)
-    let winning_amount = win_payout - amount; // 2000
-    let expected_fee = (winning_amount * taker_fee_percentage) / types::max_fee_percentage(); // 100
+    // Calculate expected fee: 5% of winning amount (2000 USDC)
+    let winning_amount = win_payout - amount; // 2000 USDC
+    let expected_fee = (winning_amount * taker_fee_percentage) / types::max_fee_percentage(); // 100 USDC
 
     // Assert event with fee
     order::assert_note_settled_event(note_id, 0, spot_price, win_payout, expected_fee);
 
-    let amount_after_fee = winning_amount - expected_fee; // 1900
+    let amount_after_fee = winning_amount - expected_fee; // 1900 USDC
 
     // Verify taker balance
     test_scenario::next_tx(&mut scenario, trader1);
@@ -481,10 +481,10 @@ public fun test_settle_loss_up_direction() {
     let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
 
     // Set maker fee percentage to 10%
-    let maker_fee_percentage = 100000000u64; // 10% (1e9 precision)
+    let maker_fee_percentage = 10000u64; // 10% (5 decimal precision)
     test_utils::set_fee_percentages(&mut scenario, &mut order_manager, 0, maker_fee_percentage);
 
-    let amount = 1_000;
+    let amount = 1_000_000_000_000; // 1000 USDC with 9 decimal precision
     let win_payout = amount * 3;
     deposit_trader_funds(&mut scenario, &mut vault, trader1, amount);
     
@@ -501,19 +501,19 @@ public fun test_settle_loss_up_direction() {
     test_scenario::next_tx(&mut scenario, coordinator);
     advance_time(&mut clock, 3 * 24 * 60 * 60 * 1000);
 
-    let spot_price = 84000 + 1; // > start and <= start+almost_win_spread => LOSS
+    let spot_price = 84000000000000 + 1000000000; // > start and <= start+almost_win_spread => LOSS (9 decimal precision)
 
     test_scenario::next_tx(&mut scenario, coordinator);
     let coordinator_cap2 = scenario.take_from_sender<CoordinatorCap>();
     order::settle_note(&coordinator_cap2, &mut order_manager, &mut vault, &mut maker_vault, note_id, spot_price, &clock, ctx(&mut scenario));
     scenario.return_to_sender(coordinator_cap2);
 
-    // Calculate expected fee: 10% of loss amount (1000)
-    let expected_fee = (amount * maker_fee_percentage) / types::max_fee_percentage(); // 100
+    // Calculate expected fee: 10% of loss amount (1000 USDC)
+    let expected_fee = (amount * maker_fee_percentage) / types::max_fee_percentage(); // 100 USDC
 
     order::assert_note_settled_event(note_id, 1, spot_price, amount, expected_fee);
 
-    let amount_after_fee = amount - expected_fee; // 900
+    let amount_after_fee = amount - expected_fee; // 900 USDC
     
     // Verify taker balance
     test_scenario::next_tx(&mut scenario, trader1);
@@ -547,10 +547,10 @@ public fun test_settle_refund_up_direction() {
     let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
 
     // Set both fee percentages to make sure no fees are applied on refund
-    let fee_percentage = 50000000u64; // 5% (1e9 precision)
+    let fee_percentage = 5000u64; // 5% (5 decimal precision)
     test_utils::set_fee_percentages(&mut scenario, &mut order_manager, fee_percentage, fee_percentage);
 
-    let amount = 1_000;
+    let amount = 1_000_000_000_000; // 1000 USDC with 9 decimal precision
     let win_payout = amount * 3;
     deposit_trader_funds(&mut scenario, &mut vault, trader1, amount);
     
@@ -566,7 +566,7 @@ public fun test_settle_refund_up_direction() {
     test_scenario::next_tx(&mut scenario, coordinator);
     advance_time(&mut clock, 3 * 24 * 60 * 60 * 1000);
 
-    let spot_price = 84000 - 1; // < start => REFUND
+    let spot_price = 84000000000000 - 1000000000; // < start => REFUND (9 decimal precision)
 
     test_scenario::next_tx(&mut scenario, coordinator);
     let coordinator_cap2 = scenario.take_from_sender<CoordinatorCap>();
@@ -611,14 +611,14 @@ public fun test_settle_refund_less_than_amount_up_direction() {
     // Fees should not apply on refund
     test_utils::set_fee_percentages(&mut scenario, &mut order_manager, 999, 888);
 
-    let amount = 1_000_000;
+    let amount = 1_000_000_000_000; // 1,000 USDC with 9 decimal precision
     let win_payout = amount * 3;
     deposit_trader_funds(&mut scenario, &mut vault, trader1, amount);
 
     let prev_taker_balance = vault::taker_balance(&vault, trader1);
     let prev_maker_balance = maker_vault::get_maker_collateral(&maker_vault, maker1, &types::tradable_asset_btc());
 
-    let refund_payout = amount - 123_456; // maker gains 123_456
+    let refund_payout = amount - 123_456_000_000; // maker gains 123.456 USDC
 
     let note = create_custom_note(
         trader1,
@@ -626,12 +626,12 @@ public fun test_settle_refund_less_than_amount_up_direction() {
         types::tradable_asset_btc(),
         types::direction_up(),
         amount,
-        84000,
-        15,
+        84000000000000, // 84k USD with 9 decimal precision
+        15000000000,    // 15 USD with 9 decimal precision
         win_payout,
         timestamp_plus_days(&clock, 2),
         /* refund */ refund_payout,
-        /* almost_win_spread */ 10,
+        /* almost_win_spread */ 10000000000, // 10 USD with 9 decimal precision
         /* almost_win_payout */ amount // not used in refund
     );
 
@@ -643,7 +643,7 @@ public fun test_settle_refund_less_than_amount_up_direction() {
     test_scenario::next_tx(&mut scenario, coordinator);
     advance_time(&mut clock, 3 * 24 * 60 * 60 * 1000);
 
-    let spot_price = 84000 - 1; // refund band
+    let spot_price = 84000000000000 - 1000000000; // refund band (9 decimal precision)
 
     test_scenario::next_tx(&mut scenario, coordinator);
     let coord2 = scenario.take_from_sender<CoordinatorCap>();
@@ -682,10 +682,10 @@ public fun test_settle_almost_win_up_direction() {
     let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
 
     // Set both fee percentages to test almost win scenario
-    let fee_percentage = 75000000u64; // 7.5% (1e9 precision)
+    let fee_percentage = 7500u64; // 7.5% (5 decimal precision)
     test_utils::set_fee_percentages(&mut scenario, &mut order_manager, fee_percentage, fee_percentage);
 
-    let amount = 1_000;
+    let amount = 1_000_000_000_000; // 1000 USDC with 9 decimal precision
     let win_payout = amount * 3;
     deposit_trader_funds(&mut scenario, &mut vault, trader1, amount);
     
@@ -701,7 +701,7 @@ public fun test_settle_almost_win_up_direction() {
     test_scenario::next_tx(&mut scenario, coordinator);
     advance_time(&mut clock, 3 * 24 * 60 * 60 * 1000);
 
-    let spot_price = 84000 + 11; // > start + almost_win_spread (10) and <= spread (15)
+    let spot_price = 84000000000000 + 11000000000; // > start + almost_win_spread (10) and <= spread (15) (9 decimal precision)
 
     test_scenario::next_tx(&mut scenario, coordinator);
     let coordinator_cap2 = scenario.take_from_sender<CoordinatorCap>();
@@ -709,15 +709,15 @@ public fun test_settle_almost_win_up_direction() {
     scenario.return_to_sender(coordinator_cap2);
 
     // For almost win, the payout is greater than amount, so taker gains and pays fee
-    // almost_win_payout = 2000, amount = 1000, transfer = 1000
-    let transfer_amount = types::note_almost_win_payout(&note) - amount; // 1000
-    let expected_fee = (transfer_amount * fee_percentage) / types::max_fee_percentage(); // 75
+    // almost_win_payout = 2000 USDC, amount = 1000 USDC, transfer = 1000 USDC
+    let transfer_amount = types::note_almost_win_payout(&note) - amount; // 1000 USDC
+    let expected_fee = (transfer_amount * fee_percentage) / types::max_fee_percentage(); // 75 USDC
 
     order::assert_note_settled_event(note_id, 3, spot_price, types::note_almost_win_payout(&note), expected_fee);
 
     let almost_win_payout = types::note_almost_win_payout(&note);
-    let transfer_amount = almost_win_payout - amount; // 1000
-    let amount_after_fee = transfer_amount - expected_fee; // 925
+    let transfer_amount = almost_win_payout - amount; // 1000 USDC
+    let amount_after_fee = transfer_amount - expected_fee; // 925 USDC
 
     // Verify taker balance
     test_scenario::next_tx(&mut scenario, trader1);
@@ -751,7 +751,7 @@ public fun test_settle_almost_win_equal_amount_up_direction() {
     let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
 
     // Set fees (should not apply when no transfer)
-    let fee_percentage = 60000000u64; // 6% (1e9 precision)
+    let fee_percentage = 6000u64; // 6% (5 decimal precision)
     test_utils::set_fee_percentages(&mut scenario, &mut order_manager, fee_percentage, fee_percentage);
 
     let amount = 1_000_000;
@@ -823,7 +823,7 @@ public fun test_settle_almost_win_less_than_amount_up_direction() {
     let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
 
     // Maker fee will apply when maker gains
-    let maker_fee_percentage = 80000000u64; // 8% (1e9 precision)
+    let maker_fee_percentage = 8000u64; // 8% (5 decimal precision)
     test_utils::set_fee_percentages(&mut scenario, &mut order_manager, 0, maker_fee_percentage);
 
     let amount = 1_000_000;
@@ -901,7 +901,7 @@ public fun test_settle_variants_down_direction() {
     let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
 
     // Set taker fee percentage for win scenario
-    let taker_fee_percentage = 90000000u64; // 9% (1e9 precision)
+    let taker_fee_percentage = 9000u64; // 9% (5 decimal precision)
     test_utils::set_fee_percentages(&mut scenario, &mut order_manager, taker_fee_percentage, 0);
 
     let amount = 1_000;

--- a/tests/order_tests.move
+++ b/tests/order_tests.move
@@ -601,6 +601,80 @@ public fun test_settle_refund_up_direction() {
     cleanup_scenario(scenario)
 }
 
+
+#[test]
+public fun test_settle_refund_less_than_amount_up_direction() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    // Fees should not apply on refund
+    test_utils::set_fee_percentages(&mut scenario, &mut order_manager, 999, 888);
+
+    let amount = 1_000_000;
+    let win_payout = amount * 3;
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, amount);
+
+    let prev_taker_balance = vault::taker_balance(&vault, trader1);
+    let prev_maker_balance = maker_vault::get_maker_collateral(&maker_vault, maker1, &types::tradable_asset_btc());
+
+    let refund_payout = amount - 123_456; // maker gains 123_456
+
+    let note = create_custom_note(
+        trader1,
+        maker1,
+        types::tradable_asset_btc(),
+        types::direction_up(),
+        amount,
+        84000,
+        15,
+        win_payout,
+        timestamp_plus_days(&clock, 2),
+        /* refund */ refund_payout,
+        /* almost_win_spread */ 10,
+        /* almost_win_payout */ amount // not used in refund
+    );
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coord = scenario.take_from_sender<CoordinatorCap>();
+    let note_id = order::create_note(&coord, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coord);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    advance_time(&mut clock, 3 * 24 * 60 * 60 * 1000);
+
+    let spot_price = 84000 - 1; // refund band
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coord2 = scenario.take_from_sender<CoordinatorCap>();
+    order::settle_note(&coord2, &mut order_manager, &mut vault, &mut maker_vault, note_id, spot_price, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coord2);
+
+    order::assert_note_settled_event(note_id, 2, spot_price, refund_payout, 0);
+
+    let transferred = amount - refund_payout; // maker gains this
+
+    test_scenario::next_tx(&mut scenario, trader1);
+    let final_taker_balance = vault::taker_balance(&vault, trader1);
+    assert_eq(final_taker_balance, prev_taker_balance - transferred);
+
+    test_scenario::next_tx(&mut scenario, maker1);
+    let final_maker_balance = maker_vault::get_maker_collateral(&maker_vault, maker1, &types::tradable_asset_btc());
+    assert_eq(final_maker_balance, prev_maker_balance + transferred);
+
+    let final_vault_asset = vault::total_asset_available(&vault);
+    assert_eq(final_vault_asset, prev_taker_balance - transferred);
+
+    let final_maker_vault_asset = maker_vault::total_asset_available(&maker_vault);
+    assert_eq(final_maker_vault_asset, prev_maker_balance + transferred);
+
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    clock.destroy_for_testing();
+    cleanup_scenario(scenario)
+}
+
 #[test]
 public fun test_settle_almost_win_up_direction() {
     let mut scenario = setup_test_scenario();
@@ -669,6 +743,156 @@ public fun test_settle_almost_win_up_direction() {
     test_scenario::return_shared(order_manager);
     cleanup_scenario(scenario)
 }
+
+#[test]
+public fun test_settle_almost_win_equal_amount_up_direction() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    // Set fees (should not apply when no transfer)
+    let fee_percentage = 1000000000000000u64; // 0.1%
+    test_utils::set_fee_percentages(&mut scenario, &mut order_manager, fee_percentage, fee_percentage);
+
+    let amount = 1_000_000;
+    let win_payout = amount * 3;
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, amount);
+
+    let prev_taker_balance = vault::taker_balance(&vault, trader1);
+    let prev_maker_balance = maker_vault::get_maker_collateral(&maker_vault, maker1, &types::tradable_asset_btc());
+
+    let note = create_custom_note(
+        trader1,
+        maker1,
+        types::tradable_asset_btc(),
+        types::direction_up(),
+        amount,
+        84000,
+        15,
+        win_payout,
+        timestamp_plus_days(&clock, 2),
+        /* refund */ amount,
+        /* almost_win_spread */ 10,
+        /* almost_win_payout */ amount
+    );
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coord = scenario.take_from_sender<CoordinatorCap>();
+    let note_id = order::create_note(&coord, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coord);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    advance_time(&mut clock, 3 * 24 * 60 * 60 * 1000);
+
+    let spot_price = 84000 + 11; // almost win band
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coord2 = scenario.take_from_sender<CoordinatorCap>();
+    order::settle_note(&coord2, &mut order_manager, &mut vault, &mut maker_vault, note_id, spot_price, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coord2);
+
+    // Fee must be zero; payout equals amount
+    order::assert_note_settled_event(note_id, 3, spot_price, amount, 0);
+
+    // No net transfers
+    test_scenario::next_tx(&mut scenario, trader1);
+    let final_taker_balance = vault::taker_balance(&vault, trader1);
+    assert_eq(final_taker_balance, prev_taker_balance);
+
+    test_scenario::next_tx(&mut scenario, maker1);
+    let final_maker_balance = maker_vault::get_maker_collateral(&maker_vault, maker1, &types::tradable_asset_btc());
+    assert_eq(final_maker_balance, prev_maker_balance);
+
+    let final_vault_asset = vault::total_asset_available(&vault);
+    assert_eq(final_vault_asset, prev_taker_balance);
+
+    let final_maker_vault_asset = maker_vault::total_asset_available(&maker_vault);
+    assert_eq(final_maker_vault_asset, prev_maker_balance);
+
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    clock.destroy_for_testing();
+    cleanup_scenario(scenario)
+}
+
+#[test]
+public fun test_settle_almost_win_less_than_amount_up_direction() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    // Maker fee will apply when maker gains
+    let maker_fee_percentage = 1000000000000000u64; // 0.1%
+    test_utils::set_fee_percentages(&mut scenario, &mut order_manager, 0, maker_fee_percentage);
+
+    let amount = 1_000_000;
+    let win_payout = amount * 3;
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, amount);
+
+    let prev_taker_balance = vault::taker_balance(&vault, trader1);
+    let prev_maker_balance = maker_vault::get_maker_collateral(&maker_vault, maker1, &types::tradable_asset_btc());
+
+    let almost_win_payout = amount - 100_000; // maker gains 100_000
+
+    let note = create_custom_note(
+        trader1,
+        maker1,
+        types::tradable_asset_btc(),
+        types::direction_up(),
+        amount,
+        84000,
+        15,
+        win_payout,
+        timestamp_plus_days(&clock, 2),
+        /* refund */ amount,
+        /* almost_win_spread */ 10,
+        /* almost_win_payout */ almost_win_payout
+    );
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coord = scenario.take_from_sender<CoordinatorCap>();
+    let note_id = order::create_note(&coord, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coord);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    advance_time(&mut clock, 3 * 24 * 60 * 60 * 1000);
+
+    let spot_price = 84000 + 11; // almost win band
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coord2 = scenario.take_from_sender<CoordinatorCap>();
+    order::settle_note(&coord2, &mut order_manager, &mut vault, &mut maker_vault, note_id, spot_price, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coord2);
+
+    let transferred = amount - almost_win_payout; // 100_000
+    let expected_fee = (transferred * maker_fee_percentage) / types::max_fee_percentage(); // 100
+
+    order::assert_note_settled_event(note_id, 3, spot_price, almost_win_payout, expected_fee);
+
+    let amount_after_fee = transferred - expected_fee;
+
+    test_scenario::next_tx(&mut scenario, trader1);
+    let final_taker_balance = vault::taker_balance(&vault, trader1);
+    assert_eq(final_taker_balance, prev_taker_balance - transferred);
+
+    test_scenario::next_tx(&mut scenario, maker1);
+    let final_maker_balance = maker_vault::get_maker_collateral(&maker_vault, maker1, &types::tradable_asset_btc());
+    assert_eq(final_maker_balance, prev_maker_balance + amount_after_fee);
+
+    let final_vault_asset = vault::total_asset_available(&vault);
+    assert_eq(final_vault_asset, prev_taker_balance - transferred);
+
+    let final_maker_vault_asset = maker_vault::total_asset_available(&maker_vault);
+    assert_eq(final_maker_vault_asset, prev_maker_balance + amount_after_fee);
+
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    clock.destroy_for_testing();
+    cleanup_scenario(scenario)
+}
+
 
 #[test]
 public fun test_settle_variants_down_direction() {
@@ -931,6 +1155,3 @@ public fun test_cannot_set_taker_fee_percentage_above_max() {
     test_scenario::return_shared(order_manager);
     cleanup_scenario(scenario)
 }
-
-
-

--- a/tests/order_tests.move
+++ b/tests/order_tests.move
@@ -22,12 +22,10 @@ use odyssey_sui::test_utils::{
     create_test_clock,
     advance_time,
     timestamp_plus_days,
-    USDC,
 };
 use odyssey_sui::types;
 use odyssey_sui::order::{Self, CoordinatorCap};
 use odyssey_sui::maker_vault;
-use odyssey_sui::test_utils::setup_order_manager;
 
 // ==========
 // Initialization Tests

--- a/tests/order_tests.move
+++ b/tests/order_tests.move
@@ -223,7 +223,7 @@ public fun test_cannot_create_note_with_refund_payout_bigger_than_amount() {
 
 #[test]
 #[expected_failure(abort_code = order::EInvalidPayout)]
-public fun test_cannot_create_note_with_almost_win_payout_zero_or_more_than_win() {
+public fun test_cannot_create_note_with_almost_win_payout_zero() {
     let mut scenario = setup_test_scenario();
     let (mut vault, mut maker_vault, mut order_manager, clock, _) = setup_funded_scenario(&mut scenario, none());
     let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
@@ -232,6 +232,30 @@ public fun test_cannot_create_note_with_almost_win_payout_zero_or_more_than_win(
 
     // almost win payout = 0
     let note = types::new_note(trader1, maker1, types::tradable_asset_btc(), types::direction_up(), 100, 84000, 15, 200, timestamp_plus_days(&clock, 2), 0, 100, 10, 0, 1);
+
+    test_scenario::next_tx(&mut scenario, coordinator);
+    let coordinator_cap = scenario.take_from_sender<CoordinatorCap>();
+    let _ = order::create_note(&coordinator_cap, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
+    scenario.return_to_sender(coordinator_cap);
+
+    test_scenario::return_shared(vault);
+    test_scenario::return_shared(maker_vault);
+    test_scenario::return_shared(order_manager);
+    clock.destroy_for_testing();
+    cleanup_scenario(scenario)
+}
+
+#[test]
+#[expected_failure(abort_code = order::EInvalidPayout)]
+public fun test_cannot_create_note_with_almost_win_payout_zero_more_than_win() {
+    let mut scenario = setup_test_scenario();
+    let (mut vault, mut maker_vault, mut order_manager, clock, _) = setup_funded_scenario(&mut scenario, none());
+    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    deposit_trader_funds(&mut scenario, &mut vault, trader1, 1000);
+
+    // almost win payout = 201, win payout = 200
+    let note = types::new_note(trader1, maker1, types::tradable_asset_btc(), types::direction_up(), 100, 84000, 15, 200, timestamp_plus_days(&clock, 2), 0, 100, 10, 201, 1);
 
     test_scenario::next_tx(&mut scenario, coordinator);
     let coordinator_cap = scenario.take_from_sender<CoordinatorCap>();

--- a/tests/order_tests.move
+++ b/tests/order_tests.move
@@ -403,7 +403,11 @@ public fun test_cannot_create_note_if_start_more_than_expiry() {
 public fun test_settle_win_up_direction() {
     let mut scenario = setup_test_scenario();
     let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
-    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+    let (governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    // Set taker fee percentage to 0.1% (smaller to avoid overflow)
+    let taker_fee_percentage = 1000000000000000u64; // 0.1%
+    test_utils::set_fee_percentages(&mut scenario, &mut order_manager, taker_fee_percentage, 0);
 
     // Prepare note
     let amount = 1_000;
@@ -416,7 +420,7 @@ public fun test_settle_win_up_direction() {
     let note_id = order::create_note(&coordinator_cap, &mut order_manager, &mut vault, &mut maker_vault, note, &clock, ctx(&mut scenario));
     scenario.return_to_sender(coordinator_cap);
 
-    // Advance time past expiry and set taker fee
+    // Advance time past expiry
     test_scenario::next_tx(&mut scenario, coordinator);
     advance_time(&mut clock, 3 * 24 * 60 * 60 * 1000);
 
@@ -426,8 +430,12 @@ public fun test_settle_win_up_direction() {
     order::settle_note(&coordinator_cap2, &mut order_manager, &mut vault, &mut maker_vault, note_id, spot_price, &clock, ctx(&mut scenario));
     scenario.return_to_sender(coordinator_cap2);
 
-    // Assert event
-    order::assert_note_settled_event(note_id, 0, spot_price, win_payout, 0);
+    // Calculate expected fee: 0.1% of winning amount (2000)
+    let winning_amount = win_payout - amount; // 2000
+    let expected_fee = (winning_amount * taker_fee_percentage) / types::max_fee_percentage(); // 2
+
+    // Assert event with fee
+    order::assert_note_settled_event(note_id, 0, spot_price, win_payout, expected_fee);
 
     // Locks reduced
     test_scenario::next_tx(&mut scenario, trader1);
@@ -446,7 +454,11 @@ public fun test_settle_win_up_direction() {
 public fun test_settle_loss_up_direction() {
     let mut scenario = setup_test_scenario();
     let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
-    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+    let (governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    // Set maker fee percentage to 0.1% (smaller to avoid overflow)
+    let maker_fee_percentage = 1000000000000000u64; // 0.1%
+    test_utils::set_fee_percentages(&mut scenario, &mut order_manager, 0, maker_fee_percentage);
 
     let amount = 1_000;
     let win_payout = amount * 3;
@@ -469,7 +481,10 @@ public fun test_settle_loss_up_direction() {
     order::settle_note(&coordinator_cap2, &mut order_manager, &mut vault, &mut maker_vault, note_id, spot_price, &clock, ctx(&mut scenario));
     scenario.return_to_sender(coordinator_cap2);
 
-    order::assert_note_settled_event(note_id, 1, spot_price, amount, 0);
+    // Calculate expected fee: 0.1% of loss amount (1000)
+    let expected_fee = (amount * maker_fee_percentage) / types::max_fee_percentage(); // 1
+
+    order::assert_note_settled_event(note_id, 1, spot_price, amount, expected_fee);
 
     test_scenario::return_shared(vault);
     test_scenario::return_shared(maker_vault);
@@ -482,7 +497,11 @@ public fun test_settle_loss_up_direction() {
 public fun test_settle_refund_up_direction() {
     let mut scenario = setup_test_scenario();
     let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
-    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+    let (governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    // Set both fee percentages to make sure no fees are applied on refund
+    let fee_percentage = 1000000000000000u64; // 0.1%
+    test_utils::set_fee_percentages(&mut scenario, &mut order_manager, fee_percentage, fee_percentage);
 
     let amount = 1_000;
     let win_payout = amount * 3;
@@ -504,6 +523,7 @@ public fun test_settle_refund_up_direction() {
     order::settle_note(&coordinator_cap2, &mut order_manager, &mut vault, &mut maker_vault, note_id, spot_price, &clock, ctx(&mut scenario));
     scenario.return_to_sender(coordinator_cap2);
 
+    // Assert event (no fee for refund)
     order::assert_note_settled_event(note_id, 2, spot_price, amount, 0);
 
     clock.destroy_for_testing();
@@ -517,7 +537,11 @@ public fun test_settle_refund_up_direction() {
 public fun test_settle_almost_win_up_direction() {
     let mut scenario = setup_test_scenario();
     let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
-    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+    let (governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    // Set both fee percentages to test almost win scenario
+    let fee_percentage = 1000000000000000u64; // 0.1%
+    test_utils::set_fee_percentages(&mut scenario, &mut order_manager, fee_percentage, fee_percentage);
 
     let amount = 1_000;
     let win_payout = amount * 3;
@@ -539,7 +563,12 @@ public fun test_settle_almost_win_up_direction() {
     order::settle_note(&coordinator_cap2, &mut order_manager, &mut vault, &mut maker_vault, note_id, spot_price, &clock, ctx(&mut scenario));
     scenario.return_to_sender(coordinator_cap2);
 
-    order::assert_note_settled_event(note_id, 3, spot_price, types::note_almost_win_payout(&note), 0);
+    // For almost win, the payout is greater than amount, so taker gains and pays fee
+    // almost_win_payout = 2000, amount = 1000, transfer = 1000
+    let transfer_amount = types::note_almost_win_payout(&note) - amount; // 1000
+    let expected_fee = (transfer_amount * fee_percentage) / types::max_fee_percentage(); // 1
+
+    order::assert_note_settled_event(note_id, 3, spot_price, types::note_almost_win_payout(&note), expected_fee);
 
     clock.destroy_for_testing();
     test_scenario::return_shared(vault);
@@ -552,7 +581,11 @@ public fun test_settle_almost_win_up_direction() {
 public fun test_settle_variants_down_direction() {
     let mut scenario = setup_test_scenario();
     let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
-    let (_, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+    let (governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+
+    // Set taker fee percentage for win scenario
+    let taker_fee_percentage = 1000000000000000u64; // 0.1%
+    test_utils::set_fee_percentages(&mut scenario, &mut order_manager, taker_fee_percentage, 0);
 
     let amount = 1_000;
     let win_payout = amount * 3;
@@ -588,7 +621,12 @@ public fun test_settle_variants_down_direction() {
     order::settle_note(&coord2, &mut order_manager, &mut vault, &mut maker_vault, note_id, spot_price_win, &clock, ctx(&mut scenario));
     scenario.return_to_sender(coord2);
 
-    order::assert_note_settled_event(note_id, 0, spot_price_win, win_payout, 0);
+    // Calculate expected fee: 0.1% of winning amount (2000)
+    let winning_amount = win_payout - amount; // 2000
+    let expected_fee = (winning_amount * taker_fee_percentage) / types::max_fee_percentage(); // 2
+
+    // Assert event with fee
+    order::assert_note_settled_event(note_id, 0, spot_price_win, win_payout, expected_fee);
 
     clock.destroy_for_testing();
     test_scenario::return_shared(vault);
@@ -778,4 +816,6 @@ public fun test_cannot_set_taker_fee_percentage_above_max() {
     test_scenario::return_shared(order_manager);
     cleanup_scenario(scenario)
 }
+
+
 

--- a/tests/order_tests.move
+++ b/tests/order_tests.move
@@ -459,7 +459,6 @@ public fun test_settle_win_up_direction() {
 
     // Verify maker vault total asset availability
     let final_maker_vault_asset = maker_vault::total_asset_available(&maker_vault);
-    debug::print(&final_maker_vault_asset);
     assert_eq(final_maker_vault_asset, prev_maker_balance - winning_amount);
 
     // Locks reduced
@@ -479,7 +478,7 @@ public fun test_settle_win_up_direction() {
 public fun test_settle_loss_up_direction() {
     let mut scenario = setup_test_scenario();
     let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
-    let (governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+    let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
 
     // Set maker fee percentage to 0.1% (smaller to avoid overflow)
     let maker_fee_percentage = 1000000000000000u64; // 0.1%
@@ -488,6 +487,9 @@ public fun test_settle_loss_up_direction() {
     let amount = 1_000;
     let win_payout = amount * 3;
     deposit_trader_funds(&mut scenario, &mut vault, trader1, amount);
+    
+    let prev_taker_balance = vault::taker_balance(&vault, trader1);
+    let prev_maker_balance = maker_vault::get_maker_collateral(&maker_vault, maker1, &types::tradable_asset_btc());
     let note = create_test_note(trader1, maker1, amount, win_payout, 2);
 
     test_scenario::next_tx(&mut scenario, coordinator);
@@ -511,6 +513,26 @@ public fun test_settle_loss_up_direction() {
 
     order::assert_note_settled_event(note_id, 1, spot_price, amount, expected_fee);
 
+    let amount_after_fee = amount - expected_fee; // 999
+    
+    // Verify taker balance
+    test_scenario::next_tx(&mut scenario, trader1);
+    let final_taker_balance = vault::taker_balance(&vault, trader1);
+    assert_eq(final_taker_balance, prev_taker_balance - amount);
+
+    // Verify maker balance
+    test_scenario::next_tx(&mut scenario, maker1);
+    let final_maker_balance = maker_vault::get_maker_collateral(&maker_vault, maker1, &types::tradable_asset_btc());
+    assert_eq(final_maker_balance, prev_maker_balance + amount_after_fee); // Maker gets amount after fee
+
+    // Verify vault total asset availability
+    let final_vault_asset = vault::total_asset_available(&vault);
+    assert_eq(final_vault_asset, prev_taker_balance - amount);
+
+    // Verify maker vault total asset availability
+    let final_maker_vault_asset = maker_vault::total_asset_available(&maker_vault);
+    assert_eq(final_maker_vault_asset, prev_maker_balance + amount_after_fee); // Maker vault has amount after fee
+
     test_scenario::return_shared(vault);
     test_scenario::return_shared(maker_vault);
     test_scenario::return_shared(order_manager);
@@ -522,7 +544,7 @@ public fun test_settle_loss_up_direction() {
 public fun test_settle_refund_up_direction() {
     let mut scenario = setup_test_scenario();
     let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
-    let (governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+    let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
 
     // Set both fee percentages to make sure no fees are applied on refund
     let fee_percentage = 1000000000000000u64; // 0.1%
@@ -531,6 +553,9 @@ public fun test_settle_refund_up_direction() {
     let amount = 1_000;
     let win_payout = amount * 3;
     deposit_trader_funds(&mut scenario, &mut vault, trader1, amount);
+    
+    let prev_taker_balance = vault::taker_balance(&vault, trader1);
+    let prev_maker_balance = maker_vault::get_maker_collateral(&maker_vault, maker1, &types::tradable_asset_btc());
     let note = create_test_note(trader1, maker1, amount, win_payout, 2);
 
     test_scenario::next_tx(&mut scenario, coordinator);
@@ -550,6 +575,24 @@ public fun test_settle_refund_up_direction() {
 
     // Assert event (no fee for refund)
     order::assert_note_settled_event(note_id, 2, spot_price, amount, 0);
+    
+    // Verify taker balance
+    test_scenario::next_tx(&mut scenario, trader1);
+    let final_taker_balance = vault::taker_balance(&vault, trader1);
+    assert_eq(final_taker_balance, prev_taker_balance); // Taker gets full refund
+
+    // Verify maker balance
+    test_scenario::next_tx(&mut scenario, maker1);
+    let final_maker_balance = maker_vault::get_maker_collateral(&maker_vault, maker1, &types::tradable_asset_btc());
+    assert_eq(final_maker_balance, prev_maker_balance); // Maker gets nothing (no fees)
+
+    // Verify vault total asset availability
+    let final_vault_asset = vault::total_asset_available(&vault);
+    assert_eq(final_vault_asset, prev_taker_balance); // Vault has the refund amount
+
+    // Verify maker vault total asset availability
+    let final_maker_vault_asset = maker_vault::total_asset_available(&maker_vault);
+    assert_eq(final_maker_vault_asset, prev_maker_balance); // Maker vault has same amount
 
     clock.destroy_for_testing();
     test_scenario::return_shared(vault);
@@ -562,7 +605,7 @@ public fun test_settle_refund_up_direction() {
 public fun test_settle_almost_win_up_direction() {
     let mut scenario = setup_test_scenario();
     let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
-    let (governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+    let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
 
     // Set both fee percentages to test almost win scenario
     let fee_percentage = 1000000000000000u64; // 0.1%
@@ -571,6 +614,9 @@ public fun test_settle_almost_win_up_direction() {
     let amount = 1_000;
     let win_payout = amount * 3;
     deposit_trader_funds(&mut scenario, &mut vault, trader1, amount);
+    
+    let prev_taker_balance = vault::taker_balance(&vault, trader1);
+    let prev_maker_balance = maker_vault::get_maker_collateral(&maker_vault, maker1, &types::tradable_asset_btc());
     let note = create_test_note(trader1, maker1, amount, win_payout, 2);
 
     test_scenario::next_tx(&mut scenario, coordinator);
@@ -595,6 +641,28 @@ public fun test_settle_almost_win_up_direction() {
 
     order::assert_note_settled_event(note_id, 3, spot_price, types::note_almost_win_payout(&note), expected_fee);
 
+    let almost_win_payout = types::note_almost_win_payout(&note);
+    let transfer_amount = almost_win_payout - amount; // 1000
+    let amount_after_fee = transfer_amount - expected_fee; // 999
+
+    // Verify taker balance
+    test_scenario::next_tx(&mut scenario, trader1);
+    let final_taker_balance = vault::taker_balance(&vault, trader1);
+    assert_eq(final_taker_balance, prev_taker_balance + amount_after_fee); // Taker gets transfer amount after fee
+
+    // Verify maker balance
+    test_scenario::next_tx(&mut scenario, maker1);
+    let final_maker_balance = maker_vault::get_maker_collateral(&maker_vault, maker1, &types::tradable_asset_btc());
+    assert_eq(final_maker_balance, prev_maker_balance - transfer_amount); // Maker loses the transfer amount
+
+    // Verify vault total asset availability
+    let final_vault_asset = vault::total_asset_available(&vault);
+    assert_eq(final_vault_asset, prev_taker_balance + amount_after_fee); // Vault has transfer amount after fee
+
+    // Verify maker vault total asset availability
+    let final_maker_vault_asset = maker_vault::total_asset_available(&maker_vault);
+    assert_eq(final_maker_vault_asset, prev_maker_balance - transfer_amount); // Maker vault has reduced amount
+
     clock.destroy_for_testing();
     test_scenario::return_shared(vault);
     test_scenario::return_shared(maker_vault);
@@ -606,7 +674,7 @@ public fun test_settle_almost_win_up_direction() {
 public fun test_settle_variants_down_direction() {
     let mut scenario = setup_test_scenario();
     let (mut vault, mut maker_vault, mut order_manager, mut clock, _) = setup_funded_scenario(&mut scenario, none());
-    let (governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
+    let (_governor, trader1, _, maker1, _, _, coordinator) = get_test_addresses();
 
     // Set taker fee percentage for win scenario
     let taker_fee_percentage = 1000000000000000u64; // 0.1%
@@ -616,6 +684,8 @@ public fun test_settle_variants_down_direction() {
     let win_payout = amount * 3;
     deposit_trader_funds(&mut scenario, &mut vault, trader1, amount);
 
+    let prev_taker_balance = vault::taker_balance(&vault, trader1);
+    let prev_maker_balance = maker_vault::get_maker_collateral(&maker_vault, maker1, &types::tradable_asset_btc());
     let note = create_custom_note(
         trader1,
         maker1,
@@ -652,6 +722,26 @@ public fun test_settle_variants_down_direction() {
 
     // Assert event with fee
     order::assert_note_settled_event(note_id, 0, spot_price_win, win_payout, expected_fee);
+
+    let amount_after_fee = winning_amount - expected_fee; // 1998
+
+    // Verify taker balance
+    test_scenario::next_tx(&mut scenario, trader1);
+    let final_taker_balance = vault::taker_balance(&vault, trader1);
+    assert_eq(final_taker_balance, prev_taker_balance + amount_after_fee); // Taker gets amount after fee
+
+    // Verify maker balance
+    test_scenario::next_tx(&mut scenario, maker1);
+    let final_maker_balance = maker_vault::get_maker_collateral(&maker_vault, maker1, &types::tradable_asset_btc());
+    assert_eq(final_maker_balance, prev_maker_balance - winning_amount); // Maker loses the full winning amount
+
+    // Verify vault total asset availability
+    let final_vault_asset = vault::total_asset_available(&vault);
+    assert_eq(final_vault_asset, prev_taker_balance + amount_after_fee); // Vault has amount after fee
+
+    // Verify maker vault total asset availability
+    let final_maker_vault_asset = maker_vault::total_asset_available(&maker_vault);
+    assert_eq(final_maker_vault_asset, prev_maker_balance - winning_amount); // Maker vault has reduced amount
 
     clock.destroy_for_testing();
     test_scenario::return_shared(vault);

--- a/tests/test_utils.move
+++ b/tests/test_utils.move
@@ -9,6 +9,7 @@ use odyssey_sui::vault::{Self, Vault, VaultAdminCap, OrderCap};
 use odyssey_sui::maker_vault::{Self, MakerVault, MakerVaultAdminCap, MakerOrderCap};
 use odyssey_sui::order::{Self, OrderManager, OrderAdminCap};
 use sui::test_utils::assert_eq;
+use std::option::none;
 
 // Test token types
 public struct USDC has drop {}
@@ -104,16 +105,24 @@ public fun setup_maker_vault(scenario: &mut Scenario, mut minimum_stake: Option<
 public fun setup_order_manager(
     scenario: &mut Scenario,
     vault_order_cap: OrderCap,
-    maker_order_cap: MakerOrderCap
+    maker_order_cap: MakerOrderCap,
+    mut custom_treasury: Option<address>
 ): (OrderManager<USDC>) {
     let (governor, _, _, _, _, treasury, coordinator) = get_test_addresses();
 
     test_scenario::next_tx(scenario, governor);
     order::test_init(ctx(scenario));
 
+    let used_treasury: address = if (option::is_some(&custom_treasury)) {
+        let treasury_address = option::extract(&mut custom_treasury);
+        treasury_address
+    } else {
+        treasury
+    };
+
     test_scenario::next_tx(scenario, governor);
     let order_admin_cap = scenario.take_from_sender<OrderAdminCap>();
-    let coordinator_cap = order::initialize<USDC>(&order_admin_cap, vault_order_cap, maker_order_cap, treasury, ctx(scenario));
+    let coordinator_cap = order::initialize<USDC>(&order_admin_cap, vault_order_cap, maker_order_cap, used_treasury, ctx(scenario));
     transfer::public_transfer(coordinator_cap, coordinator);
     scenario.return_to_sender(order_admin_cap);
 
@@ -126,7 +135,7 @@ public fun setup_order_manager(
 
 /// Complete system setup
 #[test_only]
-public fun setup_complete_system(scenario: &mut Scenario, minimum_stake: Option<u64>): (
+public fun setup_complete_system(scenario: &mut Scenario, minimum_stake: Option<u64>, mut custom_treasury: Option<address>): (
     Vault<USDC>,
     MakerVault<USDC, ITHACA>,
     OrderManager<USDC>
@@ -136,7 +145,8 @@ public fun setup_complete_system(scenario: &mut Scenario, minimum_stake: Option<
     let (order_manager) = setup_order_manager(
         scenario, 
         order_cap,
-        maker_order_cap
+        maker_order_cap,
+        custom_treasury
     );
     
     (vault, maker_vault, order_manager)
@@ -261,7 +271,7 @@ public fun setup_funded_scenario(scenario: &mut Scenario, minimum_stake: Option<
     Clock,
     u64
 ) {
-    let (vault, mut maker_vault, order_manager) = setup_complete_system(scenario, minimum_stake);    
+    let (vault, mut maker_vault, order_manager) = setup_complete_system(scenario, minimum_stake, none());    
     let clock = create_test_clock(scenario, START_MS); // Arbitrary timestamp
 
     // Register and fund maker

--- a/tests/test_utils.move
+++ b/tests/test_utils.move
@@ -324,6 +324,23 @@ public fun timestamp_plus_hours(clock: &Clock, hours: u64): u64 {
     clock::timestamp_ms(clock) + (hours * HOUR_MS)
 }
 
+/// Set both taker and maker fee percentages for testing
+#[test_only]
+public fun set_fee_percentages(
+    scenario: &mut Scenario,
+    order_manager: &mut OrderManager<USDC>,
+    taker_fee_percentage: u64,
+    maker_fee_percentage: u64
+) {
+    let (governor, _, _, _, _, _, _) = get_test_addresses();
+    
+    test_scenario::next_tx(scenario, governor);
+    let admin_cap = scenario.take_from_sender<OrderAdminCap>();
+    order::set_taker_fee_percentage(&admin_cap, order_manager, taker_fee_percentage);
+    order::set_maker_fee_percentage(&admin_cap, order_manager, maker_fee_percentage);
+    scenario.return_to_sender(admin_cap);
+}
+
 /// Cleanup test scenario
 #[test_only]
 public fun cleanup_scenario(scenario: Scenario) {

--- a/tests/test_utils.move
+++ b/tests/test_utils.move
@@ -216,13 +216,13 @@ public fun create_test_note(
         types::tradable_asset_btc(),        // asset (BTC)
         types::direction_up(),              // direction (UP)
         amount,                             // amount
-        84000,                              // starting_price (84k USD, scaled)
-        15,                                 // spread (15 USD)
+        84000000000000,                     // starting_price (84k USD, 9 decimal precision)
+        15000000000,                        // spread (15 USD, 9 decimal precision)
         win_payout,                         // win_payout
         START_MS + day_to_expire * DAY_MS,  // expiry_time
         0,                                  // nonce
         amount,                             // refund_payout (full refund)
-        10,                                 // almost_win_spread (10 USD)
+        10000000000,                        // almost_win_spread (10 USD, 9 decimal precision)
         amount + (win_payout - amount) / 2, // almost_win_payout (halfway)
         START_MS                            // start_time
     )
@@ -276,7 +276,7 @@ public fun setup_funded_scenario(scenario: &mut Scenario, minimum_stake: Option<
 
     // Register and fund maker
     register_test_maker(scenario, &mut maker_vault, MAKER_1, MINIMUM_STAKE);
-    let maker_deposit_amount = 10_000_000;
+    let maker_deposit_amount = 50_000_000_000_000; // 50,000 USDC with 9 decimal precision
     deposit_maker_collateral(scenario, &mut maker_vault, MAKER_1, types::tradable_asset_btc(), maker_deposit_amount);
     
     (vault, maker_vault, order_manager, clock, maker_deposit_amount)

--- a/tests/test_utils.move
+++ b/tests/test_utils.move
@@ -135,7 +135,7 @@ public fun setup_order_manager(
 
 /// Complete system setup
 #[test_only]
-public fun setup_complete_system(scenario: &mut Scenario, minimum_stake: Option<u64>, mut custom_treasury: Option<address>): (
+public fun setup_complete_system(scenario: &mut Scenario, minimum_stake: Option<u64>, custom_treasury: Option<address>): (
     Vault<USDC>,
     MakerVault<USDC, ITHACA>,
     OrderManager<USDC>

--- a/tests/vault_tests.move
+++ b/tests/vault_tests.move
@@ -89,7 +89,7 @@ public fun test_cannot_deposit_zero_amount() {
 public fun test_withdraw_success() {
     let mut scenario = setup_test_scenario();
     let (_, trader1, trader2, _, _, _, _) = get_test_addresses();
-    let (mut vault, maker_vault, mut order_manager) = setup_complete_system(&mut scenario, none());
+    let (mut vault, maker_vault, mut order_manager) = setup_complete_system(&mut scenario, none(), none());
     test_scenario::return_shared(maker_vault);
 
     // Mint USDC and deposit into vault
@@ -142,7 +142,7 @@ public fun test_withdraw_success() {
 public fun test_cannot_withdraw_zero_amount() {
     let mut scenario = setup_test_scenario();
     let (_, trader1, trader2, _, _, _, _) = get_test_addresses();
-    let (mut vault, maker_vault, mut order_manager) = setup_complete_system(&mut scenario, none());
+    let (mut vault, maker_vault, mut order_manager) = setup_complete_system(&mut scenario, none(), none());
     test_scenario::return_shared(maker_vault);
 
     // Mint USDC and deposit into vault
@@ -170,7 +170,7 @@ public fun test_cannot_withdraw_zero_amount() {
 public fun test_can_withdraw_remaining_nonlocked_balance() {
     let mut scenario = setup_test_scenario();
     let (_, trader1, trader2, _, _, _, _) = get_test_addresses();
-    let (mut vault, maker_vault, mut order_manager) = setup_complete_system(&mut scenario, none());
+    let (mut vault, maker_vault, mut order_manager) = setup_complete_system(&mut scenario, none(), none());
     test_scenario::return_shared(maker_vault);
 
     // Mint USDC and deposit into vault


### PR DESCRIPTION
resolves #16 

## Other Changes
- I also found issue with overflow, where SUI supports only u64 instead of u256 solidity for balances. SUI uses 9 decimals, so I changed the order tests to use 9 decimals
- for calculation that's prone to overflow, its mostly percentage calculation, so I update it to parse it to u256 temporarily before changing it back to u64.
- For the fee, in solidity, it uses 18 decimals, here, I change it to use just 5 decimals, so it supports only 2 decimal places, e.g. 0.05% 